### PR TITLE
Add D1-backed e2e CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,68 @@ jobs:
           NEXT_PUBLIC_CHAT_WORKER_URL: http://localhost:8788
           NEXT_PUBLIC_DEFAULT_LOCALE: it
 
+  e2e-test:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Migrate local D1
+        run: |
+          rm -rf backend/.wrangler/e2e
+          cat > backend/wrangler.toml <<'EOF'
+          name = "menu-backend-e2e"
+          main = "src/index.ts"
+          compatibility_date = "2025-04-11"
+
+          [vars]
+          APP_ENV = "development"
+          API_VERSION = "v1"
+          SERVICE_NAME = "menu-backend"
+          DEMO_MODE = "true"
+
+          [[d1_databases]]
+          binding = "DB"
+          database_name = "menu-db"
+          database_id = "00000000-0000-0000-0000-000000000000"
+          migrations_dir = "drizzle"
+          EOF
+          cd backend
+          npx wrangler d1 migrations apply menu-db --local --persist-to .wrangler/e2e
+      - name: Start backend and seed demo data
+        run: |
+          cd backend
+          npx wrangler dev --port 8787 --persist-to .wrangler/e2e > ../backend-e2e.log 2>&1 &
+          echo $! > ../backend-e2e.pid
+          for i in {1..60}; do
+            curl -fsS http://localhost:8787/ready && break
+            sleep 1
+          done
+          curl -fsS -X POST http://localhost:8787/admin/demo/reset
+          curl -fsS http://localhost:8787/catalog | node -e "let s='';process.stdin.on('data',c=>s+=c).on('end',()=>{const c=JSON.parse(s); const entries=c.categories.flatMap(x=>x.entries); if (!entries.length) throw new Error('seed produced no entries'); console.log(`seeded ${entries.length} entries`)})"
+      - name: Run D1-backed Playwright E2E
+        run: npm --workspace web run test:e2e -- d1-catalog.spec.ts --project=chromium
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:8787
+          NEXT_PUBLIC_CHAT_WORKER_URL: http://localhost:8788
+          NEXT_PUBLIC_DEFAULT_LOCALE: it
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          if-no-files-found: ignore
+      - name: Show backend log on failure
+        if: failure()
+        run: cat backend-e2e.log || true
+
   demo-frontend-build:
     name: Demo frontend build
     runs-on: ubuntu-latest

--- a/web/e2e/d1-catalog.spec.ts
+++ b/web/e2e/d1-catalog.spec.ts
@@ -6,18 +6,18 @@
  * - Categories and entries render
  * - No JS console errors from the API layer
  *
- * Requires: wrangler dev --remote on port 8787 + Next.js dev on port 3000
- * with NEXT_PUBLIC_API_URL=http://localhost:8787 in .env.local
+ * Requires: wrangler dev on port 8787 + Next.js dev on port 3000
+ * with NEXT_PUBLIC_API_URL=http://localhost:8787.
  */
 
 import { test, expect } from "@playwright/test";
 
 const BACKEND = "http://localhost:8787";
-const RESTAURANT_ID = "demo-restaurant";
+const CATALOG_URL = `${BACKEND}/catalog`;
 
 test.describe("D1 catalog — backend API", () => {
   test("catalog endpoint returns 200 with menu data", async ({ request }) => {
-    const resp = await request.get(`${BACKEND}/catalog/${RESTAURANT_ID}`);
+    const resp = await request.get(CATALOG_URL);
     expect(resp.status()).toBe(200);
 
     const body = await resp.json();
@@ -27,12 +27,11 @@ test.describe("D1 catalog — backend API", () => {
   });
 
   test("all prices are euros not integer cents", async ({ request }) => {
-    const resp = await request.get(`${BACKEND}/catalog/${RESTAURANT_ID}`);
+    const resp = await request.get(CATALOG_URL);
     const body = await resp.json();
 
-    const allEntries = body.menus.flatMap(
-      (m: { categories: { entries: { name: string; price: number }[] }[] }) =>
-        m.categories.flatMap((c) => c.entries)
+    const allEntries = body.categories.flatMap(
+      (c: { entries: { name: string; price: number }[] }) => c.entries
     );
 
     expect(allEntries.length).toBeGreaterThan(0);
@@ -47,9 +46,9 @@ test.describe("D1 catalog — backend API", () => {
   test("catalog source header is live-db or r2-snapshot", async ({
     request,
   }) => {
-    const resp = await request.get(`${BACKEND}/catalog/${RESTAURANT_ID}`);
+    const resp = await request.get(CATALOG_URL);
     const source = resp.headers()["x-catalog-source"];
-    expect(["live-db", "r2-snapshot"]).toContain(source);
+    expect(["live-db", "r2-snapshot", "cache-api"]).toContain(source);
   });
 
   test("health endpoint reports D1 database configured", async ({
@@ -101,7 +100,7 @@ test.describe("D1 catalog — frontend", () => {
     // Give React a moment to fire the catalog fetch
     await page.waitForTimeout(3000);
 
-    const catalogHits = apiRequests.filter((u) => u.includes("/catalog/"));
+    const catalogHits = apiRequests.filter((u) => u.includes("/catalog"));
     expect(catalogHits.length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
Adds a CI e2e job that migrates local D1, reseeds demo data, then runs the D1-backed Playwright catalog spec.