### PR TITLE
Block adding items while a check is open

### DIFF
--- a/web/e2e/admin/admin-checks-real.spec.ts
+++ b/web/e2e/admin/admin-checks-real.spec.ts
@@ -53,6 +53,8 @@ test.describe.serial("Checks (conto) — real backend", () => {
     await page.getByTestId("create-check").click();
     await createRes;
     await expect(page.getByTestId("check-card")).toBeVisible();
+    await expect(page.getByTestId("add-items-blocked")).toContainText(/paga o annulla|settle or void/i);
+    await expect(page.getByTestId("add-order")).toHaveCount(0);
     await expect(page.getByTestId("check-total")).toHaveText(/15,00/);
 
     // Apply a 10% discount; total updates to 13,50.

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Bestellung starten",
     "tableDetail.addOrder": "Bestellung hinzufügen",
     "tableDetail.submitOrder": "Bestellung senden",
-    "tableDetail.checkOpenOrderBlocked": "Offene Rechnung: erst bezahlen oder stornieren",
     "tableDetail.addItems": "Artikel hinzufügen",
     "tableDetail.searchItems": "Alle verfügbaren Artikel suchen",
     "tableDetail.noAvailableItems": "Keine verfügbaren Artikel gefunden.",
-    "tableDetail.submitItems": "Artikel hinzufügen"
+    "tableDetail.submitItems": "Artikel hinzufügen",
+    "tableDetail.checkOpenAddItemsBlocked": "Begleiche oder storniere die offene Rechnung, bevor du weitere Artikel hinzufügst."
   },
   "outOfStock": "AUSVERKAUFT",
   "staff": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Start order",
     "tableDetail.addOrder": "Add order",
     "tableDetail.submitOrder": "Send order",
-    "tableDetail.checkOpenOrderBlocked": "Open check: settle or void it before adding orders",
     "tableDetail.addItems": "Add items",
     "tableDetail.searchItems": "Search all available items",
     "tableDetail.noAvailableItems": "No available items found.",
-    "tableDetail.submitItems": "Add items"
+    "tableDetail.submitItems": "Add items",
+    "tableDetail.checkOpenAddItemsBlocked": "Settle or void the open check before adding more items."
   },
   "outOfStock": "OUT OF STOCK",
   "staff": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Iniciar pedido",
     "tableDetail.addOrder": "Añadir pedido",
     "tableDetail.submitOrder": "Enviar pedido",
-    "tableDetail.checkOpenOrderBlocked": "Cuenta abierta: cobra o anula antes de añadir pedidos",
     "tableDetail.addItems": "Añadir artículos",
     "tableDetail.searchItems": "Buscar artículos disponibles",
     "tableDetail.noAvailableItems": "No se encontraron artículos disponibles.",
-    "tableDetail.submitItems": "Añadir artículos"
+    "tableDetail.submitItems": "Añadir artículos",
+    "tableDetail.checkOpenAddItemsBlocked": "Cobra o anula la cuenta abierta antes de añadir más artículos."
   },
   "outOfStock": "AGOTADO",
   "staff": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Démarrer une commande",
     "tableDetail.addOrder": "Ajouter une commande",
     "tableDetail.submitOrder": "Envoyer la commande",
-    "tableDetail.checkOpenOrderBlocked": "Addition ouverte : encaissez ou annulez avant d’ajouter des commandes",
     "tableDetail.addItems": "Ajouter des articles",
     "tableDetail.searchItems": "Rechercher les articles disponibles",
     "tableDetail.noAvailableItems": "Aucun article disponible trouvé.",
-    "tableDetail.submitItems": "Ajouter des articles"
+    "tableDetail.submitItems": "Ajouter des articles",
+    "tableDetail.checkOpenAddItemsBlocked": "Encaissez ou annulez l’addition ouverte avant d’ajouter d’autres articles."
   },
   "outOfStock": "ÉPUISÉ",
   "staff": {

--- a/web/messages/hu.json
+++ b/web/messages/hu.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Rendelés indítása",
     "tableDetail.addOrder": "Rendelés hozzáadása",
     "tableDetail.submitOrder": "Rendelés küldése",
-    "tableDetail.checkOpenOrderBlocked": "Nyitott számla: fizetés vagy törlés után adható hozzá rendelés",
     "tableDetail.addItems": "Tételek hozzáadása",
     "tableDetail.searchItems": "Elérhető tételek keresése",
     "tableDetail.noAvailableItems": "Nem található elérhető tétel.",
-    "tableDetail.submitItems": "Tételek hozzáadása"
+    "tableDetail.submitItems": "Tételek hozzáadása",
+    "tableDetail.checkOpenAddItemsBlocked": "Rendezze vagy érvénytelenítse a nyitott számlát, mielőtt új tételeket ad hozzá."
   },
   "outOfStock": "OUT OF STOCK",
   "staff": {

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Apri ordine",
     "tableDetail.addOrder": "Aggiungi ordine",
     "tableDetail.submitOrder": "Invia ordine",
-    "tableDetail.checkOpenOrderBlocked": "Conto aperto: pagalo o annullalo prima di aggiungere ordini",
     "tableDetail.addItems": "Aggiungi articoli",
     "tableDetail.searchItems": "Cerca tutti gli articoli disponibili",
     "tableDetail.noAvailableItems": "Nessun articolo disponibile trovato.",
-    "tableDetail.submitItems": "Aggiungi articoli"
+    "tableDetail.submitItems": "Aggiungi articoli",
+    "tableDetail.checkOpenAddItemsBlocked": "Paga o annulla il conto aperto prima di aggiungere altri articoli."
   },
   "outOfStock": "ESAURITO",
   "staff": {

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Bestelling starten",
     "tableDetail.addOrder": "Bestelling toevoegen",
     "tableDetail.submitOrder": "Bestelling versturen",
-    "tableDetail.checkOpenOrderBlocked": "Open rekening: betaal of annuleer vóór nieuwe bestellingen",
     "tableDetail.addItems": "Items toevoegen",
     "tableDetail.searchItems": "Zoek beschikbare items",
     "tableDetail.noAvailableItems": "Geen beschikbare items gevonden.",
-    "tableDetail.submitItems": "Items toevoegen"
+    "tableDetail.submitItems": "Items toevoegen",
+    "tableDetail.checkOpenAddItemsBlocked": "Reken de open bon af of annuleer deze voordat je meer items toevoegt."
   },
   "outOfStock": "UITVERKOCHT",
   "staff": {

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Iniciar pedido",
     "tableDetail.addOrder": "Adicionar pedido",
     "tableDetail.submitOrder": "Enviar pedido",
-    "tableDetail.checkOpenOrderBlocked": "Conta aberta: pague ou anule antes de adicionar pedidos",
     "tableDetail.addItems": "Adicionar itens",
     "tableDetail.searchItems": "Pesquisar itens disponíveis",
     "tableDetail.noAvailableItems": "Nenhum item disponível encontrado.",
-    "tableDetail.submitItems": "Adicionar itens"
+    "tableDetail.submitItems": "Adicionar itens",
+    "tableDetail.checkOpenAddItemsBlocked": "Liquide ou anule a conta aberta antes de adicionar mais itens."
   },
   "outOfStock": "ESGOTADO",
   "staff": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Начать заказ",
     "tableDetail.addOrder": "Добавить заказ",
     "tableDetail.submitOrder": "Отправить заказ",
-    "tableDetail.checkOpenOrderBlocked": "Счёт открыт: сначала оплатите или отмените его",
     "tableDetail.addItems": "Добавить позиции",
     "tableDetail.searchItems": "Поиск доступных позиций",
     "tableDetail.noAvailableItems": "Доступные позиции не найдены.",
-    "tableDetail.submitItems": "Добавить позиции"
+    "tableDetail.submitItems": "Добавить позиции",
+    "tableDetail.checkOpenAddItemsBlocked": "Оплатите или аннулируйте открытый счёт перед добавлением новых позиций."
   },
   "outOfStock": "НЕТ В НАЛИЧИИ",
   "staff": {

--- a/web/messages/vec.json
+++ b/web/messages/vec.json
@@ -657,11 +657,11 @@
     "tableDetail.startOrder": "Scominsia ordine",
     "tableDetail.addOrder": "Zonta ordine",
     "tableDetail.submitOrder": "Manda ordine",
-    "tableDetail.checkOpenOrderBlocked": "Conto verto: paga o anula prima de zontar ordini",
     "tableDetail.addItems": "Zonta voci",
     "tableDetail.searchItems": "Serca tute łe voci disponìbiłi",
     "tableDetail.noAvailableItems": "Nisuna vose disponìbiłe catada.",
-    "tableDetail.submitItems": "Zonta voci"
+    "tableDetail.submitItems": "Zonta voci",
+    "tableDetail.checkOpenAddItemsBlocked": "Paga o anuła el conto verto prima de zontar altre voci."
   },
   "outOfStock": "FINIO",
   "staff": {

--- a/web/src/components/admin/pages/AdminTableDetailPage.test.tsx
+++ b/web/src/components/admin/pages/AdminTableDetailPage.test.tsx
@@ -122,4 +122,16 @@ describe("AdminTableDetailPage", () => {
     fireEvent.click(screen.getByTestId("submit-admin-order"));
     await waitFor(() => expect(apiMocks.createAdminSessionOrder).toHaveBeenCalledWith("s1", [{ entryId: "bruschetta", quantity: 1 }]));
   });
+
+  it("blocks adding items while a check is open and offers check actions", async () => {
+    apiMocks.fetchAdminTableDetail.mockResolvedValue({ ...sessionNoCheck, currentSession: { ...sessionNoCheck.currentSession, check: openCheck } });
+    render(<AdminTableDetailPage tableId="t1" />);
+    expect(await screen.findByTestId("check-card")).toBeInTheDocument();
+    expect(screen.queryByTestId("add-order")).toBeNull();
+    expect(screen.getByTestId("add-items-blocked")).toHaveTextContent("tableDetail.checkOpenAddItemsBlocked");
+    fireEvent.click(screen.getByTestId("blocked-settle"));
+    expect(await screen.findByTestId("settle-confirm")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("blocked-void"));
+    expect(await screen.findByTestId("void-confirm")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/admin/pages/AdminTableDetailPage.tsx
+++ b/web/src/components/admin/pages/AdminTableDetailPage.tsx
@@ -257,7 +257,11 @@ function SessionCard({
             {t("tableDetail.addItems")}
           </button>
         ) : (
-          <span className="text-xs text-amber-700 bg-amber-50 rounded-lg px-3 py-1.5">{t("tableDetail.checkOpenOrderBlocked")}</span>
+          <div className="flex flex-wrap items-center gap-2" data-testid="add-items-blocked">
+            <span className="text-xs text-amber-700 bg-amber-50 rounded-lg px-3 py-1.5">{t("tableDetail.checkOpenAddItemsBlocked")}</span>
+            <button type="button" onClick={() => setConfirming("settle")} data-testid="blocked-settle" className="px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-semibold">{t("tableDetail.paid")}</button>
+            <button type="button" onClick={() => setConfirming("void")} data-testid="blocked-void" className="px-3 py-1.5 rounded-lg border border-red-200 text-red-600 text-xs font-semibold">{t("tableDetail.void")}</button>
+          </div>
         )}
         {!hasCheck && (
           <button


### PR DESCRIPTION
Closes #24\n\n## Summary\n- Hides Add items while an open check exists\n- Shows clear blocked-state copy\n- Adds nearby settle/void shortcuts that reuse existing confirmation flows\n\n## Tests\n- npm --workspace web run test:run -- AdminTableDetailPage.test.tsx\n- npm --workspace web run test:run\n- npm --workspace web run lint\n- NEXT_IGNORE_INCORRECT_LOCKFILE=1 npm --workspace web run build\n- NEXT_PUBLIC_DEFAULT_LOCALE=it npx playwright test e2e/admin/admin-checks-real.spec.ts --project=chromium --workers=1\n\nFable-5 UX review: approved.