### PR TITLE
Require payment method when settling checks

### DIFF
--- a/backend/drizzle/0019_check_payment.sql
+++ b/backend/drizzle/0019_check_payment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE checks ADD COLUMN payment_method TEXT;
+ALTER TABLE checks ADD COLUMN note TEXT;

--- a/backend/src/__tests__/checks.test.ts
+++ b/backend/src/__tests__/checks.test.ts
@@ -173,15 +173,23 @@ describe('check patch (discount/adjustments)', () => {
 });
 
 describe('check settle / void', () => {
-  it('settle closes the session and marks the check settled', async () => {
+  it('settle requires and stores payment metadata, then closes the session', async () => {
     const db = checksDb();
     const sessionId = openSession(db);
     seedOrder(db, sessionId, 'Bruschetta', 750, 1);
     const id = ((await (await createCheck(db, sessionId)).json()) as { id: string }).id;
-    const res = await testRequest(`/admin/checks/${id}/settle`, { method: 'POST', headers: await adminHeaders(), env: adminEnv(db) });
+
+    const missing = await testRequest(`/admin/checks/${id}/settle`, { method: 'POST', headers: await adminHeaders(), env: adminEnv(db) });
+    expect(missing.status).toBe(400);
+
+    const res = await testRequest(`/admin/checks/${id}/settle`, { method: 'POST', body: { paymentMethod: 'card', note: 'Visa ending 42' }, headers: await adminHeaders(), env: adminEnv(db) });
     expect(res.status).toBe(200);
-    expect((await res.json() as { status: string; settledAt: number | null }).status).toBe('settled');
+    const body = await res.json() as { status: string; settledAt: number | null; paymentMethod: string; note: string | null };
+    expect(body.status).toBe('settled');
+    expect(body.paymentMethod).toBe('card');
+    expect(body.note).toBe('Visa ending 42');
     expect((db.raw.prepare('SELECT closed_at FROM table_sessions WHERE id = ?').get(sessionId) as { closed_at: number | null }).closed_at).not.toBeNull();
+    expect((db.raw.prepare('SELECT payment_method, note FROM checks WHERE id = ?').get(id) as { payment_method: string; note: string })).toEqual({ payment_method: 'card', note: 'Visa ending 42' });
   });
 
   it('refuses settling a non-open check (409)', async () => {
@@ -189,8 +197,8 @@ describe('check settle / void', () => {
     const sessionId = openSession(db);
     seedOrder(db, sessionId, 'Bruschetta', 750, 1);
     const id = ((await (await createCheck(db, sessionId)).json()) as { id: string }).id;
-    await testRequest(`/admin/checks/${id}/settle`, { method: 'POST', headers: await adminHeaders(), env: adminEnv(db) });
-    const again = await testRequest(`/admin/checks/${id}/settle`, { method: 'POST', headers: await adminHeaders(), env: adminEnv(db) });
+    await testRequest(`/admin/checks/${id}/settle`, { method: 'POST', body: { paymentMethod: 'cash' }, headers: await adminHeaders(), env: adminEnv(db) });
+    const again = await testRequest(`/admin/checks/${id}/settle`, { method: 'POST', body: { paymentMethod: 'cash' }, headers: await adminHeaders(), env: adminEnv(db) });
     expect(again.status).toBe(409);
   });
 

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -466,6 +466,8 @@ export const checks = sqliteTable(
     adjustments: jsonColumn<{ label: string; amount: number }[]>('adjustments').notNull().default([]),
     createdAt: integer('created_at').notNull().$defaultFn(() => Date.now()),
     settledAt: integer('settled_at'),
+    paymentMethod: text('payment_method'),
+    note: text('note'),
     voidedAt: integer('voided_at'),
   },
   (table) => ({

--- a/backend/src/routes/admin-checks.ts
+++ b/backend/src/routes/admin-checks.ts
@@ -5,7 +5,7 @@ import { requireAdmin } from '../middleware/admin-guard';
 import { requireDb } from '../middleware/db';
 import { parseBody } from '../lib/validate';
 import { z } from 'zod';
-import { UpdateCheckBodySchema, computeCheckTotals, type CheckDTO, type CheckLine } from '@menu/schemas';
+import { UpdateCheckBodySchema, SettleCheckBodySchema, computeCheckTotals, type CheckDTO, type CheckLine } from '@menu/schemas';
 import * as schema from '../db/schema';
 import type { AppBindings } from '../types';
 import type { DbInstance } from '../db';
@@ -41,6 +41,8 @@ function toCheckDTO(row: CheckRow): CheckDTO {
     total,
     createdAt: row.createdAt,
     settledAt: row.settledAt,
+    paymentMethod: row.paymentMethod as CheckDTO['paymentMethod'],
+    note: row.note,
     voidedAt: row.voidedAt,
   };
 }
@@ -262,9 +264,11 @@ admin.post('/checks/:id/settle', ...base, async (c) => {
   if (!row) return c.json({ error: 'Not Found' }, 404);
   if (row.status !== 'open') return c.json({ error: 'not_open' }, 409);
 
+  const body = await parseBody(c, SettleCheckBodySchema);
+  if (body instanceof Response) return body;
   const now = Date.now();
   await db.batch([
-    db.update(schema.checks).set({ status: 'settled', settledAt: now }).where(eq(schema.checks.id, id)),
+    db.update(schema.checks).set({ status: 'settled', settledAt: now, paymentMethod: body.paymentMethod, note: body.note ?? null }).where(eq(schema.checks.id, id)),
     db.update(schema.tableSessions).set({ closedAt: now }).where(eq(schema.tableSessions.id, row.tableSessionId)),
   ]);
   const [updated] = await db.select().from(schema.checks).where(eq(schema.checks.id, id)).limit(1);

--- a/packages/schemas/src/checks.ts
+++ b/packages/schemas/src/checks.ts
@@ -9,6 +9,7 @@ import type { StaffOrder, TableShape } from './staff.js';
 // the client and server agree.
 
 export type CheckStatus = 'open' | 'settled' | 'voided';
+export type PaymentMethod = 'cash' | 'card' | 'other';
 
 export interface CheckLine {
   name: string;
@@ -39,6 +40,8 @@ export interface CheckDTO {
   total: number;
   createdAt: number;
   settledAt: number | null;
+  paymentMethod: PaymentMethod | null;
+  note: string | null;
   voidedAt: number | null;
 }
 
@@ -80,6 +83,12 @@ export const UpdateCheckBodySchema = z.object({
   adjustments: z.array(AdjustmentSchema).max(20).optional(),
 });
 export type UpdateCheckBody = z.infer<typeof UpdateCheckBodySchema>;
+
+export const SettleCheckBodySchema = z.object({
+  paymentMethod: z.enum(['cash', 'card', 'other']),
+  note: z.string().trim().max(120).optional(),
+});
+export type SettleCheckBody = z.infer<typeof SettleCheckBodySchema>;
 
 // ── Admin table detail (#15 follow-up) ──────────────────────────────
 

--- a/web/e2e/admin/admin-checks-real.spec.ts
+++ b/web/e2e/admin/admin-checks-real.spec.ts
@@ -74,12 +74,15 @@ test.describe.serial("Checks (conto) — real backend", () => {
 
     // Settle (confirm) → session closes, table free, settled in history.
     await page.getByTestId("settle").click();
+    await expect(page.getByTestId("settle-confirm")).toBeDisabled();
+    await page.getByTestId("payment-method-card").click();
     const settleRes = page.waitForResponse((res) => res.url().includes("/settle") && res.request().method() === "POST" && res.status() < 300);
     await page.getByTestId("settle-confirm").click();
     await settleRes;
 
     await expect(page.getByTestId("table-free")).toBeVisible();
     await expect(page.getByText(/Pagato|Paid/).first()).toBeVisible();
+    await expect(page.getByText(/Carta|Card/).first()).toBeVisible();
   });
   test("admin adds searchable items from the table page", async ({ page, request }) => {
     await seedSessionWithOrder(request);

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "Keine verfügbaren Artikel gefunden.",
     "tableDetail.submitItems": "Artikel hinzufügen",
     "tableDetail.checkOpenAddItemsBlocked": "Begleiche oder storniere die offene Rechnung, bevor du weitere Artikel hinzufügst.",
-    "tables.checkOpen": "Rechnung"
+    "tables.checkOpen": "Rechnung",
+    "tableDetail.settlementTitle": "Zahlung",
+    "tableDetail.paymentMethod.cash": "Bar",
+    "tableDetail.paymentMethod.card": "Karte",
+    "tableDetail.paymentMethod.other": "Andere",
+    "tableDetail.paymentNote": "Zahlungsnotiz (optional)"
   },
   "outOfStock": "AUSVERKAUFT",
   "staff": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "No available items found.",
     "tableDetail.submitItems": "Add items",
     "tableDetail.checkOpenAddItemsBlocked": "Settle or void the open check before adding more items.",
-    "tables.checkOpen": "Check"
+    "tables.checkOpen": "Check",
+    "tableDetail.settlementTitle": "Payment",
+    "tableDetail.paymentMethod.cash": "Cash",
+    "tableDetail.paymentMethod.card": "Card",
+    "tableDetail.paymentMethod.other": "Other",
+    "tableDetail.paymentNote": "Payment note (optional)"
   },
   "outOfStock": "OUT OF STOCK",
   "staff": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "No se encontraron artículos disponibles.",
     "tableDetail.submitItems": "Añadir artículos",
     "tableDetail.checkOpenAddItemsBlocked": "Cobra o anula la cuenta abierta antes de añadir más artículos.",
-    "tables.checkOpen": "Cuenta"
+    "tables.checkOpen": "Cuenta",
+    "tableDetail.settlementTitle": "Pago",
+    "tableDetail.paymentMethod.cash": "Efectivo",
+    "tableDetail.paymentMethod.card": "Tarjeta",
+    "tableDetail.paymentMethod.other": "Otro",
+    "tableDetail.paymentNote": "Nota de pago (opcional)"
   },
   "outOfStock": "AGOTADO",
   "staff": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "Aucun article disponible trouvé.",
     "tableDetail.submitItems": "Ajouter des articles",
     "tableDetail.checkOpenAddItemsBlocked": "Encaissez ou annulez l’addition ouverte avant d’ajouter d’autres articles.",
-    "tables.checkOpen": "Note"
+    "tables.checkOpen": "Note",
+    "tableDetail.settlementTitle": "Paiement",
+    "tableDetail.paymentMethod.cash": "Espèces",
+    "tableDetail.paymentMethod.card": "Carte",
+    "tableDetail.paymentMethod.other": "Autre",
+    "tableDetail.paymentNote": "Note de paiement (facultatif)"
   },
   "outOfStock": "ÉPUISÉ",
   "staff": {

--- a/web/messages/hu.json
+++ b/web/messages/hu.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "Nem található elérhető tétel.",
     "tableDetail.submitItems": "Tételek hozzáadása",
     "tableDetail.checkOpenAddItemsBlocked": "Rendezze vagy érvénytelenítse a nyitott számlát, mielőtt új tételeket ad hozzá.",
-    "tables.checkOpen": "Számla"
+    "tables.checkOpen": "Számla",
+    "tableDetail.settlementTitle": "Fizetés",
+    "tableDetail.paymentMethod.cash": "Készpénz",
+    "tableDetail.paymentMethod.card": "Kártya",
+    "tableDetail.paymentMethod.other": "Egyéb",
+    "tableDetail.paymentNote": "Fizetési megjegyzés (opcionális)"
   },
   "outOfStock": "OUT OF STOCK",
   "staff": {

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "Nessun articolo disponibile trovato.",
     "tableDetail.submitItems": "Aggiungi articoli",
     "tableDetail.checkOpenAddItemsBlocked": "Paga o annulla il conto aperto prima di aggiungere altri articoli.",
-    "tables.checkOpen": "Conto"
+    "tables.checkOpen": "Conto",
+    "tableDetail.settlementTitle": "Pagamento",
+    "tableDetail.paymentMethod.cash": "Contanti",
+    "tableDetail.paymentMethod.card": "Carta",
+    "tableDetail.paymentMethod.other": "Altro",
+    "tableDetail.paymentNote": "Nota pagamento (opzionale)"
   },
   "outOfStock": "ESAURITO",
   "staff": {

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "Geen beschikbare items gevonden.",
     "tableDetail.submitItems": "Items toevoegen",
     "tableDetail.checkOpenAddItemsBlocked": "Reken de open bon af of annuleer deze voordat je meer items toevoegt.",
-    "tables.checkOpen": "Rekening"
+    "tables.checkOpen": "Rekening",
+    "tableDetail.settlementTitle": "Betaling",
+    "tableDetail.paymentMethod.cash": "Contant",
+    "tableDetail.paymentMethod.card": "Kaart",
+    "tableDetail.paymentMethod.other": "Anders",
+    "tableDetail.paymentNote": "Betaalnotitie (optioneel)"
   },
   "outOfStock": "UITVERKOCHT",
   "staff": {

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "Nenhum item disponível encontrado.",
     "tableDetail.submitItems": "Adicionar itens",
     "tableDetail.checkOpenAddItemsBlocked": "Liquide ou anule a conta aberta antes de adicionar mais itens.",
-    "tables.checkOpen": "Conta"
+    "tables.checkOpen": "Conta",
+    "tableDetail.settlementTitle": "Pagamento",
+    "tableDetail.paymentMethod.cash": "Dinheiro",
+    "tableDetail.paymentMethod.card": "Cartão",
+    "tableDetail.paymentMethod.other": "Outro",
+    "tableDetail.paymentNote": "Nota de pagamento (opcional)"
   },
   "outOfStock": "ESGOTADO",
   "staff": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "Доступные позиции не найдены.",
     "tableDetail.submitItems": "Добавить позиции",
     "tableDetail.checkOpenAddItemsBlocked": "Оплатите или аннулируйте открытый счёт перед добавлением новых позиций.",
-    "tables.checkOpen": "Счет"
+    "tables.checkOpen": "Счет",
+    "tableDetail.settlementTitle": "Оплата",
+    "tableDetail.paymentMethod.cash": "Наличные",
+    "tableDetail.paymentMethod.card": "Карта",
+    "tableDetail.paymentMethod.other": "Другое",
+    "tableDetail.paymentNote": "Примечание к оплате (необязательно)"
   },
   "outOfStock": "НЕТ В НАЛИЧИИ",
   "staff": {

--- a/web/messages/vec.json
+++ b/web/messages/vec.json
@@ -662,7 +662,12 @@
     "tableDetail.noAvailableItems": "Nisuna vose disponìbiłe catada.",
     "tableDetail.submitItems": "Zonta voci",
     "tableDetail.checkOpenAddItemsBlocked": "Paga o anuła el conto verto prima de zontar altre voci.",
-    "tables.checkOpen": "Conto"
+    "tables.checkOpen": "Conto",
+    "tableDetail.settlementTitle": "Pagamento",
+    "tableDetail.paymentMethod.cash": "Contanti",
+    "tableDetail.paymentMethod.card": "Carta",
+    "tableDetail.paymentMethod.other": "Altro",
+    "tableDetail.paymentNote": "Nota pagamento (opsional)"
   },
   "outOfStock": "FINIO",
   "staff": {

--- a/web/src/components/admin/pages/AdminTableDetailPage.test.tsx
+++ b/web/src/components/admin/pages/AdminTableDetailPage.test.tsx
@@ -37,7 +37,7 @@ const openCheck = {
   id: "c1", status: "open" as const,
   lines: [{ name: "Bruschetta", quantity: 2, unitPrice: 750 }],
   discount: null, adjustments: [],
-  subtotal: 1500, total: 1500, createdAt: 1, settledAt: null, voidedAt: null,
+  subtotal: 1500, total: 1500, createdAt: 1, settledAt: null, paymentMethod: null, note: null, voidedAt: null,
 };
 
 beforeEach(() => {
@@ -78,13 +78,18 @@ describe("AdminTableDetailPage", () => {
     await waitFor(() => expect(screen.getByTestId("check-total")).toHaveTextContent("13,50"));
   });
 
-  it("settles the check behind an inline confirm", async () => {
+  it("requires payment method in a settlement sheet before settling", async () => {
     apiMocks.fetchAdminTableDetail.mockResolvedValue({ ...sessionNoCheck, currentSession: { ...sessionNoCheck.currentSession, check: openCheck } });
-    apiMocks.settleCheck.mockResolvedValue({ ...openCheck, status: "settled", settledAt: 2 });
+    apiMocks.settleCheck.mockResolvedValue({ ...openCheck, status: "settled", settledAt: 2, paymentMethod: "card", note: "Visa" });
     render(<AdminTableDetailPage tableId="t1" />);
     fireEvent.click(await screen.findByTestId("settle"));
-    fireEvent.click(await screen.findByTestId("settle-confirm"));
-    await waitFor(() => expect(apiMocks.settleCheck).toHaveBeenCalledWith("c1"));
+    const confirm = await screen.findByTestId("settle-confirm");
+    expect(confirm).toBeDisabled();
+    fireEvent.click(screen.getByTestId("payment-method-card"));
+    fireEvent.change(screen.getByTestId("payment-note"), { target: { value: "Visa" } });
+    expect(confirm).not.toBeDisabled();
+    fireEvent.click(confirm);
+    await waitFor(() => expect(apiMocks.settleCheck).toHaveBeenCalledWith("c1", { paymentMethod: "card", note: "Visa" }));
   });
 
   it("shows the free empty state when there is no open session", async () => {
@@ -130,8 +135,18 @@ describe("AdminTableDetailPage", () => {
     expect(screen.queryByTestId("add-order")).toBeNull();
     expect(screen.getByTestId("add-items-blocked")).toHaveTextContent("tableDetail.checkOpenAddItemsBlocked");
     fireEvent.click(screen.getByTestId("blocked-settle"));
-    expect(await screen.findByTestId("settle-confirm")).toBeInTheDocument();
+    expect(await screen.findByTestId("settlement-sheet")).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("blocked-void"));
     expect(await screen.findByTestId("void-confirm")).toBeInTheDocument();
+  });
+
+  it("shows payment method in settled history", async () => {
+    apiMocks.fetchAdminTableDetail.mockResolvedValue({
+      ...sessionNoCheck,
+      currentSession: null,
+      history: [{ sessionId: "h1", openedAt: 1, closedAt: 2, check: { ...openCheck, status: "settled", settledAt: 2, paymentMethod: "cash" } }],
+    });
+    render(<AdminTableDetailPage tableId="t1" />);
+    expect(await screen.findByTestId("history-payment-h1")).toHaveTextContent("tableDetail.paymentMethod.cash");
   });
 });

--- a/web/src/components/admin/pages/AdminTableDetailPage.tsx
+++ b/web/src/components/admin/pages/AdminTableDetailPage.tsx
@@ -8,7 +8,7 @@ import {
   ApiError, type AdminTableDetail, type CheckDTO, type CatalogResponse, type SubmitOrderLine,
 } from "@/lib/api";
 import { useTranslations } from "@/lib/i18n";
-import type { CheckAdjustment, CheckDiscount } from "@menu/schemas";
+import type { CheckAdjustment, CheckDiscount, PaymentMethod } from "@menu/schemas";
 
 const POLL_MS = 10_000;
 
@@ -138,7 +138,7 @@ export default function AdminTableDetailPage({ tableId }: { tableId: string }) {
           confirming={confirming}
           setConfirming={setConfirming}
           onUpdate={(patch) => run(() => updateCheck(check.id, patch))}
-          onSettle={() => run(() => settleCheck(check.id))}
+          onSettle={(body) => run(() => settleCheck(check.id, body))}
           onVoid={() => run(() => voidCheck(check.id))}
         />
       )}
@@ -163,6 +163,7 @@ export default function AdminTableDetailPage({ tableId }: { tableId: string }) {
                       <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${h.check.status === "settled" ? "bg-green-100 text-green-800" : "bg-gray-200 text-gray-600"}`}>
                         {t(`tableDetail.checkStatus.${h.check.status}`)}
                       </span>
+                      {h.check.paymentMethod && <span data-testid={`history-payment-${h.sessionId}`} className="text-xs text-gray-500">{t(`tableDetail.paymentMethod.${h.check.paymentMethod}`)}</span>}
                       <span className="text-sm font-bold text-gray-900">{euros(h.check.total)}</span>
                     </span>
                   )}
@@ -365,7 +366,7 @@ function CheckCard({
   confirming: "close" | "settle" | "void" | null;
   setConfirming: (v: "close" | "settle" | "void" | null) => void;
   onUpdate: (patch: { discount?: CheckDiscount | null; adjustments?: CheckAdjustment[] }) => void;
-  onSettle: () => void;
+  onSettle: (body: { paymentMethod: PaymentMethod; note?: string }) => void;
   onVoid: () => void;
 }) {
   const [discountType, setDiscountType] = useState<"percent" | "amount">(check.discount?.type ?? "percent");
@@ -374,6 +375,8 @@ function CheckCard({
   );
   const [adjLabel, setAdjLabel] = useState("");
   const [adjAmount, setAdjAmount] = useState("");
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null);
+  const [paymentNote, setPaymentNote] = useState("");
 
   const saveDiscount = () => {
     const raw = discountValue.trim();
@@ -453,10 +456,37 @@ function CheckCard({
       <div className="mt-4 flex flex-wrap gap-2 print-hide">
         <button type="button" onClick={() => window.print()} className="px-3 py-1.5 rounded-lg border border-gray-200 text-gray-600 text-xs font-semibold">{t("tableDetail.print")}</button>
         {confirming === "settle" ? (
-          <>
-            <button type="button" onClick={onSettle} disabled={busy} data-testid="settle-confirm" className="px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-semibold disabled:opacity-50">{t("tableDetail.confirmPaid")}</button>
-            <button type="button" onClick={() => setConfirming(null)} className="px-3 py-1.5 rounded-lg border border-gray-200 text-gray-600 text-xs font-semibold">{t("common.cancel")}</button>
-          </>
+          <div data-testid="settlement-sheet" className="w-full rounded-xl border border-green-100 bg-green-50 p-3 space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm font-semibold text-green-900">{t("tableDetail.settlementTitle")}</span>
+              <span className="text-lg font-bold text-green-900">{euros(check.total)}</span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {(["cash", "card", "other"] as PaymentMethod[]).map((method) => (
+                <button
+                  key={method}
+                  type="button"
+                  onClick={() => setPaymentMethod(method)}
+                  data-testid={`payment-method-${method}`}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-semibold border ${paymentMethod === method ? "bg-green-600 text-white border-green-600" : "bg-white text-gray-700 border-gray-200"}`}
+                >
+                  {t(`tableDetail.paymentMethod.${method}`)}
+                </button>
+              ))}
+            </div>
+            <input
+              value={paymentNote}
+              onChange={(e) => setPaymentNote(e.target.value)}
+              data-testid="payment-note"
+              maxLength={120}
+              placeholder={t("tableDetail.paymentNote")}
+              className="h-9 w-full rounded-lg border border-gray-200 px-3 text-sm bg-white"
+            />
+            <div className="flex flex-wrap gap-2">
+              <button type="button" onClick={() => paymentMethod && onSettle({ paymentMethod, note: paymentNote.trim() || undefined })} disabled={busy || !paymentMethod} data-testid="settle-confirm" className="px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-semibold disabled:opacity-50">{t("tableDetail.confirmPaid")}</button>
+              <button type="button" onClick={() => setConfirming(null)} className="px-3 py-1.5 rounded-lg border border-gray-200 text-gray-600 text-xs font-semibold bg-white">{t("common.cancel")}</button>
+            </div>
+          </div>
         ) : (
           <button type="button" onClick={() => setConfirming("settle")} data-testid="settle" className="px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-semibold">{t("tableDetail.paid")}</button>
         )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -56,6 +56,7 @@ import type {
   AdminTableDetail,
   CheckDTO,
   UpdateCheckBody,
+  SettleCheckBody,
 } from '@menu/schemas';
 
 export type { CatalogResponse, MeResponse, AnalyticsResponse, ViewedItemRanked, MenuViewBreakdown, HourlyTotal, SubmitOrderLine };
@@ -315,8 +316,8 @@ export function updateCheck(checkId: string, data: UpdateCheckBody) {
   return apiFetch<CheckDTO>(`/admin/checks/${encodeURIComponent(checkId)}`, { method: 'PATCH', body: data, auth: true });
 }
 
-export function settleCheck(checkId: string) {
-  return apiFetch<CheckDTO>(`/admin/checks/${encodeURIComponent(checkId)}/settle`, { method: 'POST', auth: true });
+export function settleCheck(checkId: string, data: SettleCheckBody) {
+  return apiFetch<CheckDTO>(`/admin/checks/${encodeURIComponent(checkId)}/settle`, { method: 'POST', body: data, auth: true });
 }
 
 export function voidCheck(checkId: string) {


### PR DESCRIPTION
Closes #26\n\n## What\n- Adds payment method/note fields to checks\n- Requires cash/card/other in the settle API\n- Replaces immediate paid confirm with a settlement sheet\n- Shows payment method in settled history\n\n## Tests\n- npm run health\n- NEXT_IGNORE_INCORRECT_LOCKFILE=1 npm --workspace web run build\n- npm --workspace web run test:e2e -- --project=chromium --workers=1 e2e/admin/admin-checks-real.spec.ts\n\n## Review\n- GPT-5 implementation review: pass\n- Fable-5 UX review: pass